### PR TITLE
Adding TEAM-NORMS.md document

### DIFF
--- a/docs/TEAM-NORMS.md
+++ b/docs/TEAM-NORMS.md
@@ -1,0 +1,62 @@
+# Team Norms
+
+**Team Members:**
+- Name: Ashray Sikka
+- Name: Ajay Paterson
+- Name: Michael Hubel
+
+
+## Communications
+
+Discord will be the primary method of communication for the project team via the assigned channel. Team members are expected to check Discord once per day. Persistent unresponsiveness will be raised as a group first and escalated to instructors if unresolved. If a team member is unreachable on Discord, an email will be sent.
+
+Shared Google folder for docs and Github will be the primary tools for collaboration on written work and code. Members are encouraged to ask for assistance rather than miss deadlines, treating the group as a resource. Questions for the instructors are welcome, but members should attempt to resolve within the group first.
+
+
+## Meeting Norms
+
+A mandatory weekly meeting will be held on Tuesdays at 6:00pm to determine workload review and task assignment. Additional meetings will be scheduled as needed for team discussions, collaborative work sessions, or client related topics (tentative schedule for Friday and Sunday for these). A brief agenda is encouraged to be shared so members can come prepared. Meeting facilitation and note taking responsibilities will rotate among members. Meeting transcripts and decisions will be recorded and shared in a Google Doc after each session.
+
+Members are expected to notify the group in Discord as early as possible if they cannot attend a meeting. A meeting may proceed with two of the three members present; absent members are responsible for reviewing notes and documents afterward.
+
+Decisions made in meetings are considered final unless raised for re-discussion by the next meeting.
+
+
+## Work & Contribution Standards
+
+All feature development must be done on a dedicated branch - nothing is to be developed directly on main. Pull requests require a minimum of 1 peer approval before merging; a 24 hour window is encouraged to allow additional review. Minor changes (formatting, comments, typos) may be merged with 1 approval at author's discretion.
+
+Code should be reasonably commented, functions and key logic should include a brief description of their purpose. Commit messages should be clear and descriptive of the change made. All members are expected to have meaningful contributions visible in the Github commit history.
+
+
+## Weekly Schedule & Deadlines
+
+- **Tuesday** — Mandatory team meeting to review upcoming work and assign tasks for the week.
+- **Wednesday 10:00pm MST** — Hard deadline for any work being submitted for instructor feedback.
+- **Friday** — Check-in meeting to review progress and discuss any instructor feedback received.
+- **Sunday 8:00pm MST** — Hard deadline for all code contributions for the week. Team meeting to also be scheduled on Sundays to review and prepare for Monday's presentation.
+- **Monday** — Class standup and group presentation of the previous week's work.
+
+
+## Late Submissions
+
+Members who are struggling with their work are encouraged to reach out to the group as early as possible for assistance. Members who anticipate missing the Sunday 8:00pm MST deadline must notify the group by Friday's check-in at the latest. Code not submitted by Sunday 8:00pm may be excluded from the week's merge at the group's discretion.
+
+If a member is stuck or behind, they are encouraged to reach out to the group early. The project reflects everyone and supporting each other is a shared responsibility.
+
+
+## Decision Making
+
+The group will default to consensus for most decisions. All members should be able to support the outcome even if it isn't their first preference. If consensus cannot be reached after reasonable discussion, a majority vote will be used. Minor technical decisions (like formatting preferences) may be made by the assigned member without a vote. Significant decisions affecting scope, deadlines, or workload require group discussion before a decision is made. Decisions made between meetings should be posted in Discord. Members have 24 hours to raise concerns, after which the decision is considered approved.
+
+
+## Conflict Resolution
+
+All issues should be raised and discussed openly as a team, with a genuine attempt to reach an amicable resolution. Discussions should remain respectful and focused on the project. Personal attacks and hostile language are not acceptable. If a resolution cannot be reached through discussion, the group will proceed to a majority vote.
+
+Severe infractions, including violations of program policy, hateful language or conduct harmful to the group, will be documented and brought to the instructor with a formal motion to remove the member. Removal is subject to instructor approval. Once approved, the member's standing in the project will be addressed by program administration. The member in question will have the opportunity to present their perspective to the instructor before any decision is made.
+
+
+## Strike Policy
+
+A strike serves as a formal written warning issued by the group to a member who has not met agreed upon expectations. Strikes are recorded in a dedicated shared document accessible to all group members. Any member may bring forward a strike motion; issuance requires group consensus. Accumulating three strikes, a member will be subject to removal in accordance with the Conflict Resolution policy, including instructor approval. Any action that violates the program policies or the law will bypass the strike system entirely and be referred directly to program administration or law enforcement as appropriate.


### PR DESCRIPTION
Adding the team norms document covering communications, meeting schedule, work standards, deadlines, decision making, conflict resolution and strike policy.